### PR TITLE
Fix if the same card was clicked

### DIFF
--- a/B03 - Memory Matching Game/finished/src/App.js
+++ b/B03 - Memory Matching Game/finished/src/App.js
@@ -43,6 +43,9 @@ export default function App() {
   }, [matched]);
 
   function flipCard(index) {
+    // if same card was clicked
+    if (opened.includes(index)) return;
+
     setMoves((moves) => moves + 1);
     setOpened((opened) => [...opened, index]);
   }


### PR DESCRIPTION
# Description
There is an issue now when the click is made the second time to the same card. It opens the matching card, which is not intended behavior since it reveals where the matching card is located. Please check the video below.

![screencast 2020-07-22 18-53-02](https://user-images.githubusercontent.com/5434459/88168528-2562c700-cc4d-11ea-8417-609adbef78d3.gif)


This PR is intended to fix the mentioned issue. 